### PR TITLE
fix(babel): react fragment error on compile

### DIFF
--- a/packages/reflexjs/src/babel.ts
+++ b/packages/reflexjs/src/babel.ts
@@ -14,7 +14,7 @@ export default (_, { ...options } = {}) => {
           import: pragmaName,
         },
       ],
-      [jsx, { pragma: pragmaName, pragmaFrag: "", ...options }],
+      [jsx, { pragma: pragmaName, pragmaFrag: "React.Fragment", ...options }],
     ],
   }
 }


### PR DESCRIPTION
Close: #131

Fix `React.Fragment` compile error in `<>` form