### PR TITLE
Fix icon name in Pager

### DIFF
--- a/packages/gatsby-theme-core/src/pager.js
+++ b/packages/gatsby-theme-core/src/pager.js
@@ -12,7 +12,7 @@ export const Pager = ({ previousPagePath, nextPagePath, ...props }) => (
   >
     {previousPagePath && (
       <Link to={previousPagePath} textDecoration="none" variant="button.link">
-        <Icon name="arrow-lef" mr="2" /> Previous
+        <Icon name="arrow-left" mr="2" /> Previous
       </Link>
     )}
     {nextPagePath && (


### PR DESCRIPTION
I think this was mistakenly modified at https://github.com/reflexjs/reflexjs/commit/449fe8da1d9b188d66ca1a07d2ec8a457593f2fc#diff-41f70382bf25038c507ad0ed048b87c25b66798b61885a24c441e2f5a6d37a9fR15, resulting in no "previous" arrow rendering.