### PR TITLE
fix: clone per-type defaults before generating metatags for a node

### DIFF
--- a/packages/gatsby-plugin-metatags/gatsby-node.js
+++ b/packages/gatsby-plugin-metatags/gatsby-node.js
@@ -1,6 +1,7 @@
 const merge = require("deepmerge")
 const { generateMetatags } = require("./generate-metatags")
 const withDefaults = require("./options")
+const cloneDeep = require("lodash.clonedeep")
 
 exports.createSchemaCustomization = async ({ actions }) => {
   actions.createTypes(`
@@ -92,7 +93,10 @@ exports.onCreateNode = async (
 
   // Apply defaults from options.
   if (typeOptions && typeOptions.defaults) {
-    defaults = merge(defaults, applyDefaults(node, typeOptions.defaults))
+    defaults = merge(
+      defaults,
+      applyDefaults(node, cloneDeep(typeOptions.defaults))
+    )
   }
 
   // Find metatags from the node MDX parent to use as overrides.

--- a/packages/gatsby-plugin-metatags/package.json
+++ b/packages/gatsby-plugin-metatags/package.json
@@ -38,6 +38,7 @@
     "@reflexjs/gatsby-plugin-image": "^0.5.1",
     "@reflexjs/utils": "^0.2.1",
     "gatsby-plugin-react-helmet": "^3.3.6",
+    "lodash.clonedeep": "^4.5.0",
     "react-helmet": "^6.1.0",
     "reflexjs": "^1.0.1"
   }


### PR DESCRIPTION
If a per-type metatags default provided a callback function, the first node's metatags
would be used for all successive nodes of that type. That's because `typeOptions` was
passed around by reference.

Instead, clone a fresh copy for every node so its callback function will run as expected.
