### PR TITLE
Dropdown/Popup menu: fixed no show

### DIFF
--- a/packages/gatsby-theme-nav/src/nav-menu.js
+++ b/packages/gatsby-theme-nav/src/nav-menu.js
@@ -127,7 +127,7 @@ export const NavMenuItem = ({
   ...props
 }) => {
   const [dropdownRef, isOpen, open, close] = useDropdown()
-  const isMobile = useBreakpointIndex() <= 2
+  const isMobile = useBreakpointIndex() < 1
   if (!value) return null
 
   const usingHover = trigger === "hover"


### PR DESCRIPTION
Dropdown menu was only visible if no breakpoint has been triggered (i.e., max width of the browser window). Is there any reason for the "<=2"?